### PR TITLE
Resolve issue about traces_dir parameter and goto pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "donjon-quicklog"
+packages = [{ include = "quicklog", from = "." }]
+version = "1.0.2"
+description = ""
+authors = ["Olivier Hériveaux <olivier.heriveaux@ledger.fr>"]
+license = "LGPL-3.0-or-later"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = ">=3.9 <4"
+numpy = "*"
+click = "*"
+progressbar = "*"
+
+
+[tool.poetry.scripts]
+quicklog = 'quicklog.__main__:cli'
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,0 @@
-from setuptools import setup, find_packages
-
-setup(
-    name="quicklog",
-    version="1.0.1",
-    install_requires=["numpy", "click", "progressbar"],
-    packages=find_packages(),
-)


### PR DESCRIPTION
This PR intends to make the traces_dir parameter to be used in all functions (save_trace/load_trace) ... in all modes (batch/simple)

Also update from setup.py to pyproject.toml

Note that quicklog package name is now defined as "donjon-quicklog" instead of "quicklog" which is already used in pypi